### PR TITLE
add erlang-pure-migrations to curated list

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,7 @@ A curated list of awesome Erlang frameworks, libraries and software.
 * [talentdeficit/json](https://github.com/talentdeficit/json) - a high level json library for erlang (17.0+)
 * [stolen/webdist](https://github.com/stolen/webdist) - Erlang distribution as HTTP protocol upgrade
 * [spawngrid/erlang-sql-migrations](https://github.com/spawngrid/erlang-sql-migrations) - Simple Erlang library to run SQL migrations
+* [bearmug/erlang-pure-migrations](https://github.com/bearmug/erlang-pure-migrations) – PostgreSQL/MySQL migrations for Erlang.
 * [ScottBrooks/Erlcraft](https://github.com/ScottBrooks/Erlcraft) - Erlang Minecraft server
 * [psyeugenic/fgraph](https://github.com/psyeugenic/fgraph) - Physics engine for graph drawing written in erlang for use in wxErlang or standalone.
 * [nuex/erl_gm](https://github.com/nuex/erl_gm) - An Erlang GraphicsMagick wrapper


### PR DESCRIPTION
Dear awesome list curators, here is one more tool, which I propose for the list adoption.

**What**
Awesome onboarding for database version control engine [erlang-pure-migrations](https://github.com/bearmug/erlang-pure-migrations).

**Why**
- PostgreSQL/MySQL support out-of-the-box
- a number of real and continuously verified integrations (3 for PostgreSQL and 1 for MySQL)
- reasonable errors and problems reporting
- built-in quality controls metrics
- extensive usage code snippets for each integration
- effects-free engine with detailed mechanics explanation